### PR TITLE
Add hepmc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,6 +101,7 @@ SET(
    eicsmear/erhic/EventDpmjet.h
    eicsmear/erhic/EventFactory.h
    eicsmear/erhic/EventGmcTrans.h
+   eicsmear/erhic/EventHepMC.h
    eicsmear/erhic/EventMC.h
    eicsmear/erhic/EventMCFilterABC.h
    eicsmear/erhic/EventMilou.h
@@ -162,6 +163,7 @@ SET(
    src/erhic/EventDpmjet.cxx
    src/erhic/EventFactory.cxx
    src/erhic/EventGmcTrans.cxx
+   src/erhic/EventHepMC.cxx
    src/erhic/EventMC.cxx
    src/erhic/EventMilou.cxx
    src/erhic/EventPepsi.cxx

--- a/cint/LinkDef.h
+++ b/cint/LinkDef.h
@@ -38,6 +38,7 @@
 #pragma link C++ class erhic::EventPepsi+;
 #pragma link C++ class erhic::EventDjangoh+;
 #pragma link C++ class erhic::EventDpmjet+;
+#pragma link C++ class erhic::EventHepMC+;
 #pragma link C++ class erhic::EventMilou+;
 #pragma link C++ class erhic::EventGmcTrans+;
 #pragma link C++ class erhic::EventSimple+;
@@ -47,6 +48,7 @@
 
 #pragma link C++ class erhic::VirtualEventFactory+;
 #pragma link C++ class erhic::EventFromAsciiFactory<erhic::EventPepsi>+;
+#pragma link C++ class erhic::EventFromAsciiFactory<erhic::EventHepMC>+;
 #pragma link C++ class erhic::EventFromAsciiFactory<erhic::EventMilou>+;
 #pragma link C++ class erhic::EventFromAsciiFactory<erhic::EventRapgap>+;
 #pragma link C++ class erhic::EventFromAsciiFactory<erhic::EventDjangoh>+;
@@ -79,6 +81,7 @@
 
 #pragma link C++ class erhic::FileType+;
 #pragma link C++ class erhic::File<erhic::EventPythia>+;
+#pragma link C++ class erhic::File<erhic::EventHepMC>+;
 #pragma link C++ class erhic::File<erhic::EventMilou>+;
 #pragma link C++ class erhic::File<erhic::EventPepsi>+;
 #pragma link C++ class erhic::File<erhic::EventRapgap>+;

--- a/include/eicsmear/erhic/EventFactory.h
+++ b/include/eicsmear/erhic/EventFactory.h
@@ -23,6 +23,12 @@
 #include "eicsmear/erhic/EventPythia.h"
 #include "eicsmear/smear/EventSmear.h"
 
+namespace HepMC3
+{
+class ReaderAsciiHepMC2;
+class GenEvent;
+}
+
 namespace erhic {
 
 class ParticleMC;
@@ -57,6 +63,11 @@ class VirtualEventFactory : public TObject {
    event type in branches.
    */
   virtual std::string EventName() const = 0;
+
+/**
+if we need to skip lines to get to the first event
+*/
+  virtual void FindFirstEvent() {}
 
   /**
    Add a branch named "name" for the event type generated
@@ -114,6 +125,8 @@ class EventFromAsciiFactory : public VirtualEventFactory {
    */
   virtual std::string EventName() const;
 
+  virtual void FindFirstEvent();
+
   std::istream* mInput;  //!
   std::string mLine;  //!
   std::unique_ptr<T> mEvent;  //!
@@ -163,12 +176,7 @@ class EventFromAsciiFactory<erhic::EventHepMC> : public VirtualEventFactory {
   /**
    Initialise the factory from an input stream. 
    */
-  explicit EventFromAsciiFactory(std::istream& is)
-  : mInput(&is)
-    , mEvent(nullptr) 
-{ 
-  std::cout << "creating factory HepMC" << std::endl;
-  }
+  explicit EventFromAsciiFactory(std::istream& is);
 
   /**
    Returns a new event instance.
@@ -185,6 +193,9 @@ class EventFromAsciiFactory<erhic::EventHepMC> : public VirtualEventFactory {
   std::unique_ptr<erhic::EventHepMC> mEvent;  //!
 
  protected:
+
+  HepMC3::ReaderAsciiHepMC2 *adapter2;
+  HepMC3::GenEvent *evt;
   /**
    Returns true when an end-of-event marker is encountered in the input stream.
    */
@@ -198,7 +209,7 @@ class EventFromAsciiFactory<erhic::EventHepMC> : public VirtualEventFactory {
   /**
    Create a new particle from the last data read from the input stream.
    */
-  bool AddParticle() {return false;}
+  bool AddParticle();
 
   // Warning: explicitly putting the erhic:: namespace before the class
   // name doesn't seen to work for template classes.

--- a/include/eicsmear/erhic/EventFactory.h
+++ b/include/eicsmear/erhic/EventFactory.h
@@ -146,6 +146,7 @@ class EventFromAsciiFactory : public VirtualEventFactory {
  (any event class implementing a Parse() method to
  populate the event's variables from a string will work.)
  */
+
 template<>
 class EventFromAsciiFactory<erhic::EventHepMC> : public VirtualEventFactory {
  public:
@@ -164,13 +165,15 @@ class EventFromAsciiFactory<erhic::EventHepMC> : public VirtualEventFactory {
    */
   explicit EventFromAsciiFactory(std::istream& is)
   : mInput(&is)
-  , mEvent(nullptr) {
+    , mEvent(nullptr) 
+{ 
+  std::cout << "creating factory HepMC" << std::endl;
   }
 
   /**
    Returns a new event instance.
    */
-  virtual erhic::EventHepMC* Create() {return nullptr;}
+  virtual erhic::EventHepMC* Create();
 
   /**
    Returns the name of the event class created by this factory.
@@ -185,17 +188,17 @@ class EventFromAsciiFactory<erhic::EventHepMC> : public VirtualEventFactory {
   /**
    Returns true when an end-of-event marker is encountered in the input stream.
    */
-  bool AtEndOfEvent() const;
+  bool AtEndOfEvent() const {return false;}
 
   /**
    Perform end-of-event operations.
    */
-  Int_t FinishEvent();
+  Int_t FinishEvent() {return 0;}
 
   /**
    Create a new particle from the last data read from the input stream.
    */
-  bool AddParticle();
+  bool AddParticle() {return false;}
 
   // Warning: explicitly putting the erhic:: namespace before the class
   // name doesn't seen to work for template classes.

--- a/include/eicsmear/erhic/EventFactory.h
+++ b/include/eicsmear/erhic/EventFactory.h
@@ -19,6 +19,7 @@
 
 #include "eicsmear/functions.h"
 #include "eicsmear/erhic/VirtualEvent.h"
+#include "eicsmear/erhic/EventHepMC.h"
 #include "eicsmear/erhic/EventPythia.h"
 #include "eicsmear/smear/EventSmear.h"
 
@@ -136,6 +137,69 @@ class EventFromAsciiFactory : public VirtualEventFactory {
   // Warning: explicitly putting the erhic:: namespace before the class
   // name doesn't seen to work for template classes.
   ClassDef(EventFromAsciiFactory, 1)
+};
+
+/**
+ Creates events from an input plain text file containing
+ appropriately formatted data.
+ Templated for all the types inheriting from EventMC
+ (any event class implementing a Parse() method to
+ populate the event's variables from a string will work.)
+ */
+template<>
+class EventFromAsciiFactory<erhic::EventHepMC> : public VirtualEventFactory {
+ public:
+  /**
+   Constructor.
+   */
+  EventFromAsciiFactory() { }
+
+  /**
+   Destructor.
+   */
+  virtual ~EventFromAsciiFactory() { }
+
+  /**
+   Initialise the factory from an input stream. 
+   */
+  explicit EventFromAsciiFactory(std::istream& is)
+  : mInput(&is)
+  , mEvent(nullptr) {
+  }
+
+  /**
+   Returns a new event instance.
+   */
+  virtual erhic::EventHepMC* Create() {return nullptr;}
+
+  /**
+   Returns the name of the event class created by this factory.
+   */
+  virtual std::string EventName() const;
+
+  std::istream* mInput;  //!
+  std::string mLine;  //!
+  std::unique_ptr<erhic::EventHepMC> mEvent;  //!
+
+ protected:
+  /**
+   Returns true when an end-of-event marker is encountered in the input stream.
+   */
+  bool AtEndOfEvent() const;
+
+  /**
+   Perform end-of-event operations.
+   */
+  Int_t FinishEvent();
+
+  /**
+   Create a new particle from the last data read from the input stream.
+   */
+  bool AddParticle();
+
+  // Warning: explicitly putting the erhic:: namespace before the class
+  // name doesn't seen to work for template classes.
+  ClassDef(EventFromAsciiFactory<erhic::EventHepMC>, 1)
 };
 
 }  // namespace erhic

--- a/include/eicsmear/erhic/EventFactory.h
+++ b/include/eicsmear/erhic/EventFactory.h
@@ -26,7 +26,6 @@
 namespace HepMC3
 {
 class ReaderAsciiHepMC2;
-class GenEvent;
 }
 
 namespace erhic {
@@ -195,7 +194,6 @@ class EventFromAsciiFactory<erhic::EventHepMC> : public VirtualEventFactory {
  protected:
 
   HepMC3::ReaderAsciiHepMC2 *adapter2;
-  HepMC3::GenEvent *evt;
   /**
    Returns true when an end-of-event marker is encountered in the input stream.
    */

--- a/include/eicsmear/erhic/EventHepMC.h
+++ b/include/eicsmear/erhic/EventHepMC.h
@@ -36,10 +36,9 @@ class EventHepMC : public EventMC {
    "0 eventnumber numTracks weight processId radiativeCorrectionFlag
    trueX trueQ2 trueY trueT truePhi phi phiResolution reconstructedPhi"
    \endverbatim
-   Returns true in the event of a successful read operation,
-   false in case of an error.
+   dummy - the reading is done by a hepmc reader
    */
-  virtual bool Parse(const std::string&);
+  virtual bool Parse(const std::string&) {return true;}
 
   Bool_t radcorr;
   Double32_t weight;

--- a/include/eicsmear/erhic/EventHepMC.h
+++ b/include/eicsmear/erhic/EventHepMC.h
@@ -1,0 +1,62 @@
+/**
+ \file
+ Declaration of class erhic::EventMilou.
+ 
+ \author    Thomas Burton
+ \date      2011-07-07
+ \copyright 2011 Brookhaven National Lab
+ */
+
+#ifndef INCLUDE_EICSMEAR_ERHIC_EVENTHEPMC_H_
+#define INCLUDE_EICSMEAR_ERHIC_EVENTHEPMC_H_
+
+#include <string>
+
+#include <Rtypes.h>
+
+#include "eicsmear/erhic/EventMC.h"
+
+namespace erhic {
+
+/**
+ Describes an event from the generator HEPMC.
+ */
+class EventHepMC : public EventMC {
+ public:
+  /**
+   Constructor.
+   */
+  EventHepMC();
+
+  /**
+   Parses the event information from a text string.
+   
+   The string must have the following format (no newlines):
+   \verbatim
+   "0 eventnumber numTracks weight processId radiativeCorrectionFlag
+   trueX trueQ2 trueY trueT truePhi phi phiResolution reconstructedPhi"
+   \endverbatim
+   Returns true in the event of a successful read operation,
+   false in case of an error.
+   */
+  virtual bool Parse(const std::string&);
+
+  Bool_t radcorr;
+  Double32_t weight;
+  Double32_t trueX;
+  Double32_t trueQ2;
+  Double32_t trueY;
+  Double32_t trueT;
+  Double32_t truePhi;
+  Double32_t phibelgen;  ///> the azimuthal angle between the production
+                         ///> and the scattering plane
+  Double32_t phibelres;  ///> the resolution of the previous angle
+                         ///> according to H1
+  Double32_t phibelrec;  ///> the reconstructed phi angle
+
+  ClassDef(erhic::EventHepMC, 1)
+};
+
+}  // namespace erhic
+
+#endif  // INCLUDE_EICSMEAR_ERHIC_EVENTHEPMC_H_

--- a/include/eicsmear/erhic/File.h
+++ b/include/eicsmear/erhic/File.h
@@ -19,6 +19,7 @@
 #include <TString.h>
 
 #include "eicsmear/erhic/EventBase.h"
+#include "eicsmear/erhic/EventHepMC.h"
 #include "eicsmear/erhic/EventMilou.h"
 #include "eicsmear/erhic/EventPythia.h"
 #include "eicsmear/erhic/EventFactory.h"
@@ -504,7 +505,7 @@ class File : public FileType {
    Returns a new event factory instance.
    */
   virtual EventFromAsciiFactory<T>*
-  CreateEventFactory(std::istream& is) const {
+    CreateEventFactory(std::istream& is) const {
      return new EventFromAsciiFactory<T>(is);
   }
 
@@ -516,6 +517,60 @@ class File : public FileType {
   ClassDef(File, 1)
 };
 
+template<>
+class File<erhic::EventHepMC> : public FileType {
+ public:
+
+  /**
+   Constructor.
+   
+   If the string argument is not empty, the File attempts to open
+   a file with that name. If the file is opened it tries to extract
+   */
+  File(){}
+
+  /**
+   Destructor.
+   */
+  virtual ~File(){}
+
+  /**
+   Returns a new File object.
+   */
+  virtual File<erhic::EventHepMC>* Create() const {
+  return new File<erhic::EventHepMC>();
+}
+
+  /**
+   Allocates an event of the type for this file.
+   */
+  virtual erhic::EventHepMC* AllocateEvent() const {
+  return new erhic::EventHepMC();
+}
+
+
+  /**
+   Returns the name of the generator.
+   Entirely in lower case.
+   */
+  virtual std::string GetGeneratorName() const {return "HepMC";}
+
+  /**
+   Create a LogReader for this type of Monte Carlo file.
+   Returns NULL if the file type is unsupported or has no LogReader
+   class implemented.
+   The LogReader must be deleted by the user.
+   */
+  virtual LogReader* CreateLogReader() const {return nullptr;}
+
+  EventFromAsciiFactory<erhic::EventHepMC>* CreateEventFactory(std::istream& is) const {std::cout << "boom" << std::endl;
+  return nullptr;}
+ protected:
+  erhic::EventHepMC* t_;
+
+  ClassDef(File<erhic::EventHepMC>, 1)
+};
+
 template<typename T>
 inline T* File<T>::AllocateEvent() const {
   return new T;
@@ -525,6 +580,7 @@ template<typename T>
 inline File<T>* File<T>::Create() const {
   return new File<T>();
 }
+
 
 /**
  Factory class for Files.

--- a/include/eicsmear/erhic/File.h
+++ b/include/eicsmear/erhic/File.h
@@ -563,7 +563,7 @@ class File<erhic::EventHepMC> : public FileType {
    */
   virtual LogReader* CreateLogReader() const {return nullptr;}
 
-  EventFromAsciiFactory<erhic::EventHepMC>* CreateEventFactory(std::istream& is) const {std::cout << "boom" << std::endl;
+  EventFromAsciiFactory<erhic::EventHepMC>* CreateEventFactory(std::istream& is) const {
     return new EventFromAsciiFactory<erhic::EventHepMC>(is);}
  protected:
   erhic::EventHepMC* t_;

--- a/include/eicsmear/erhic/File.h
+++ b/include/eicsmear/erhic/File.h
@@ -564,7 +564,7 @@ class File<erhic::EventHepMC> : public FileType {
   virtual LogReader* CreateLogReader() const {return nullptr;}
 
   EventFromAsciiFactory<erhic::EventHepMC>* CreateEventFactory(std::istream& is) const {std::cout << "boom" << std::endl;
-  return nullptr;}
+    return new EventFromAsciiFactory<erhic::EventHepMC>(is);}
  protected:
   erhic::EventHepMC* t_;
 

--- a/src/erhic/EventFactory.cxx
+++ b/src/erhic/EventFactory.cxx
@@ -182,6 +182,15 @@ std::string EventFromAsciiFactory<T>::EventName() const {
   return T::Class()->GetName();
 }
 
+std::string EventFromAsciiFactory<erhic::EventHepMC>::EventName() const {
+  return erhic::EventHepMC::Class()->GetName();
+}
+
+erhic::EventHepMC* EventFromAsciiFactory<erhic::EventHepMC>::Create()
+{
+  std::cout << "creating hepmc in evt factory" << std::endl;
+return nullptr;}
+
 }  // namespace erhic
 
 namespace {

--- a/src/erhic/EventFactory.cxx
+++ b/src/erhic/EventFactory.cxx
@@ -32,6 +32,16 @@
 #include "eicsmear/erhic/ParticleIdentifier.h"
 #include "eicsmear/erhic/ParticleMC.h"
 
+#include <TVector3.h>
+#include <TParticlePDG.h>
+#include <TLorentzVector.h>
+#include <TDatabasePDG.h>
+
+#include <HepMC3/ReaderAsciiHepMC2.h>
+#include <HepMC3/GenEvent.h>
+#include <HepMC3/GenVertex.h>
+#include <HepMC3/GenParticle.h>
+
 namespace erhic {
 
 template<typename T>
@@ -182,14 +192,124 @@ std::string EventFromAsciiFactory<T>::EventName() const {
   return T::Class()->GetName();
 }
 
+template<typename T>
+void EventFromAsciiFactory<T>::FindFirstEvent()  {
+  for (int i=0; i<5; i++)
+  {
+  std::getline(*mInput,mLine);
+  }
+}
+
+
+
+
+EventFromAsciiFactory<erhic::EventHepMC>::EventFromAsciiFactory(std::istream& is):
+ mInput(&is)
+    , mEvent(nullptr) 
+{   
+adapter2 = new HepMC3::ReaderAsciiHepMC2(is);
+/*
+	while(!adapter2->failed())
+	{
+        HepMC3::GenEvent evt(HepMC3::Units::GEV,HepMC3::Units::MM);
+	adapter2->read_event(evt);
+        auto vtxvec = evt.vertices();
+         std::cout << "number of vertices: " << vtxvec.size() << std::endl;
+	}
+*/
+  std::cout << "creating factory HepMC from cxx file" << std::endl;
+  }
+
+
 std::string EventFromAsciiFactory<erhic::EventHepMC>::EventName() const {
   return erhic::EventHepMC::Class()->GetName();
 }
 
 erhic::EventHepMC* EventFromAsciiFactory<erhic::EventHepMC>::Create()
 {
-  std::cout << "creating hepmc in evt factory" << std::endl;
-return nullptr;}
+	while(!adapter2->failed())
+	{
+        HepMC3::GenEvent evt(HepMC3::Units::GEV,HepMC3::Units::MM);
+	adapter2->read_event(evt);
+        auto vtxvec = evt.vertices();
+         std::cout << "number of vertices in CREATE: " << vtxvec.size() << std::endl;
+	}
+    mEvent.reset(nullptr);
+return mEvent.release();
+
+  TProcessIdObjectCount objectCount;
+  static int icnt = 0;
+  mEvent.reset(new erhic::EventHepMC());
+   std::cout << "creating hepmc in evt factory" << std::endl;
+//   std::string mLine = "I hate this guy and his complicated software POS";
+//   mEvent->Parse(mLine);
+   icnt++;
+   std::cout << "event no " << icnt << std::endl;
+std::string error;
+        evt = new HepMC3::GenEvent(HepMC3::Units::GEV,HepMC3::Units::MM);
+	adapter2->read_event(*evt);
+/*
+      if (!AddParticle()) {
+    mEvent.reset(nullptr);
+    std::cout << "done reading" << std::endl;
+        error = "Bad particle input in event";
+      }  // if
+*/
+      if (icnt > 5)
+      {
+    mEvent.reset(nullptr);
+      }
+return mEvent.release();
+}
+
+  bool EventFromAsciiFactory<erhic::EventHepMC>::AddParticle() {
+    try {
+      if (mEvent.get()) {
+        evt = new HepMC3::GenEvent(HepMC3::Units::GEV,HepMC3::Units::MM);
+	adapter2->read_event(*evt);
+	return true;
+	if (adapter2->failed())
+	{
+	  delete evt;
+	  return false;
+	}
+
+	auto vtxvec = evt->vertices();
+	for (auto v = vtxvec.begin();
+	     v != vtxvec.end();
+	     ++v)
+
+	{
+
+	  auto particlevec = (*v)->particles_out();
+	  for (auto p = particlevec.begin();
+	       p != particlevec.end(); ++p)
+	  {
+	    TParticlePDG * pdg_p = TDatabasePDG::Instance()->GetParticle( (*p)->pdg_id() );
+	    TVector3 vertex((*v)->position().x(),(*v)->position().y(),(*v)->position().z());
+	    TLorentzVector lovec;
+	    lovec.SetXYZM((*p)->momentum().px(),(*p)->momentum().py(),(*p)->momentum().pz(),pdg_p->Mass());
+	    ParticleMC particle; 
+	    particle.SetVertex(vertex);
+	    particle.Set4Vector(lovec);
+	    particle.SetEvent(mEvent.get());
+	    mEvent->AddLast(&particle);
+	  }
+	}
+	//ParticleMCeA *particle = new ParticleMCeA(mLine);  // Throws if the string is bad
+	//particle->SetEvent(mEvent.get());
+	//mEvent->AddLast(particle);
+	//delete particle;
+      }  // if
+      delete evt;
+      return true;
+    }  // try
+    catch(std::exception& error) {
+      std::cerr << "Exception building particle: " << error.what() << std::endl;
+      delete evt;
+      return false;
+    }
+  }
 
 }  // namespace erhic
 

--- a/src/erhic/EventFactory.cxx
+++ b/src/erhic/EventFactory.cxx
@@ -18,6 +18,7 @@
 
 #include "eicsmear/erhic/BeamParticles.h"
 #include "eicsmear/erhic/EventPythia.h"
+#include "eicsmear/erhic/EventHepMC.h"
 #include "eicsmear/erhic/EventMilou.h"
 #include "eicsmear/erhic/EventDjangoh.h"
 #include "eicsmear/erhic/EventDpmjet.h"
@@ -189,6 +190,7 @@ namespace {
 erhic::EventFromAsciiFactory<erhic::EventDjangoh> ed;
 erhic::EventFromAsciiFactory<erhic::EventDpmjet> ej;
 erhic::EventFromAsciiFactory<erhic::EventPepsi> ee;
+erhic::EventFromAsciiFactory<erhic::EventHepMC> eh;
 erhic::EventFromAsciiFactory<erhic::EventMilou> em;
 erhic::EventFromAsciiFactory<erhic::EventRapgap> er;
 erhic::EventFromAsciiFactory<erhic::EventPythia> ep;

--- a/src/erhic/EventHepMC.cxx
+++ b/src/erhic/EventHepMC.cxx
@@ -1,0 +1,39 @@
+/**
+ \file
+ Implementation of class erhic::EventMilou.
+ 
+ \author    Thomas Burton
+ \date      2011-07-07
+ \copyright 2011 Brookhaven National Lab
+ */
+
+#include "eicsmear/erhic/EventHepMC.h"
+
+#include <cmath>
+#include <sstream>
+#include <string>
+#include <iostream>
+
+namespace erhic {
+
+EventHepMC::EventHepMC()
+: radcorr(-1)
+, weight(NAN)
+, trueX(NAN)
+, trueQ2(NAN)
+, trueY(NAN)
+, trueT(NAN)
+, truePhi(NAN)
+, phibelgen(NAN)
+, phibelres(NAN)
+, phibelrec(NAN) {
+  std::cout << "creating HepMC Event" << std::endl;
+}
+
+bool EventHepMC::Parse(const std::string& line) {
+  static std::stringstream ss;
+  std::cout << "reading " << line << std::endl;
+return !ss.fail();
+}
+
+}  // namespace erhic

--- a/src/erhic/EventHepMC.cxx
+++ b/src/erhic/EventHepMC.cxx
@@ -27,13 +27,6 @@ EventHepMC::EventHepMC()
 , phibelgen(NAN)
 , phibelres(NAN)
 , phibelrec(NAN) {
-  std::cout << "creating HepMC Event" << std::endl;
-}
-
-bool EventHepMC::Parse(const std::string& line) {
-  static std::stringstream ss;
-  std::cout << "reading " << line << std::endl;
-return !ss.fail();
 }
 
 }  // namespace erhic

--- a/src/erhic/File.cxx
+++ b/src/erhic/File.cxx
@@ -20,6 +20,7 @@
 #include "eicsmear/erhic/EventDpmjet.h"
 #include "eicsmear/erhic/EventRapgap.h"
 #include "eicsmear/erhic/EventGmcTrans.h"
+#include "eicsmear/erhic/EventHepMC.h"
 #include "eicsmear/erhic/EventSimple.h"
 #include "eicsmear/erhic/EventSartre.h"
 
@@ -522,6 +523,23 @@ template<typename T>
 LogReader* File<T>::CreateLogReader() const {
   return LogReaderFactory::GetInstance().CreateReader(*t_);
 }
+/*
+template<>
+std::string File<erhic::EventHepMC>::GetGeneratorName() const {
+  // The event class name is "EventX" where "X" is the generator
+  // name.
+  TString name = t_->ClassName();
+  name.ReplaceAll("erhic::", "");
+  name.ReplaceAll("Event", "");
+  name.ToLower();
+  return name.Data();
+}
+
+template<>
+LogReader* File<erhic::EventHepMC>::CreateLogReader() const {
+  return LogReaderFactory::GetInstance().CreateReader(*t_);
+}
+*/
 
 FileFactory& FileFactory::GetInstance() {
   static FileFactory theInstance;
@@ -539,6 +557,10 @@ const FileType* FileFactory::GetFile(const std::string& name) const {
 const FileType* FileFactory::GetFile(std::istream& is) const {
   std::string line;
   std::getline(is, line);
+  if (line.empty())
+  {
+    std::getline(is, line);
+  }
   // Use TString::ToLower() to convert the input name to all
   // lower case.
   TString str(line);
@@ -564,6 +586,8 @@ const FileType* FileFactory::GetFile(std::istream& is) const {
     file = GetFile("simple");  
   } else if (str.Contains("sartre")) {
     file = GetFile("sartre");  
+  } else if (str.Contains("hepmc")) {
+    file = GetFile("hepmc");  
   }  // if
   return file;
 }
@@ -589,6 +613,8 @@ FileFactory::FileFactory() {
                                     new File<EventSimple>()));
   prototypes_.insert(std::make_pair("sartre",
                                     new File<EventSartre>()));
+  prototypes_.insert(std::make_pair("hepmc",
+                                    new File<EventHepMC>()));
   
 }
 

--- a/src/erhic/Forester.cxx
+++ b/src/erhic/Forester.cxx
@@ -146,7 +146,6 @@ bool Forester::OpenInput() {
       throw std::runtime_error(GetInputFileName() +
                                " is not from a supported generator");
     }  // for
-    std::cout << "creating EventFactory" << std::endl;
     mFactory = mFile->CreateEventFactory(*mTextFile);
     return true;
   }  // try...

--- a/src/erhic/Forester.cxx
+++ b/src/erhic/Forester.cxx
@@ -178,12 +178,7 @@ bool Forester::SetupOutput() {
     // Auto-save every 500 MB
     mTree->SetAutoSave(500LL * 1024LL * 1024LL);
     // Align the input file at the start of the first event (event generator dependent).
-mFactory->FindFirstEvent();
-    std::cout << "event name: " << mFactory->EventName() << std::endl;
-    // if (mFactory->EventName().find("EventHepMC") == std::string::npos)
-    // {
-    //   FindFirstEvent();
-    // }
+    mFactory->FindFirstEvent();
     // Start timing after opening and creating files,
     // before looping over events
     mStatus.StartTimer();

--- a/src/erhic/Forester.cxx
+++ b/src/erhic/Forester.cxx
@@ -146,6 +146,7 @@ bool Forester::OpenInput() {
       throw std::runtime_error(GetInputFileName() +
                                " is not from a supported generator");
     }  // for
+    std::cout << "creating EventFactory" << std::endl;
     mFactory = mFile->CreateEventFactory(*mTextFile);
     return true;
   }  // try...
@@ -176,8 +177,13 @@ bool Forester::SetupOutput() {
                   &mEvent, 32000, 99);
     // Auto-save every 500 MB
     mTree->SetAutoSave(500LL * 1024LL * 1024LL);
-    // Align the input file at the start of the first event.
-    FindFirstEvent();
+    // Align the input file at the start of the first event (event generator dependent).
+mFactory->FindFirstEvent();
+    std::cout << "event name: " << mFactory->EventName() << std::endl;
+    // if (mFactory->EventName().find("EventHepMC") == std::string::npos)
+    // {
+    //   FindFirstEvent();
+    // }
     // Start timing after opening and creating files,
     // before looping over events
     mStatus.StartTimer();


### PR DESCRIPTION
This PR adds the capability to read ASCII files in HepMC 2 format. It is still rough and we need to make sure all information is properly propagated to the eic-smear MC particles. It needs a HepMC3 installation to link against which is currently hardcoded in the cmake invocation (works after sourcing the sphenix setup script):
ccmake -i -DCMAKE_INSTALL_PREFIX=/phenix/scratch/pinkenbu/tmpeic/install -DCMAKE_SHARED_LINKER_FLAGS='-L/opt/sphenix/core/HepMC3/lib64 -lHepMC3' -DCMAKE_SKIP_INSTALL_RPATH=ON -DCMAKE_SKIP_RPATH=ON -DCMAKE_CXX_FLAGS='-std=c++11 -I/opt/sphenix/core/HepMC3/include' -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DCMAKE_VERBOSE_MAKEFILE=ON ../
