### PR TITLE
read hepmc2 and hepmc3 formatted files

### DIFF
--- a/include/eicsmear/erhic/EventFactoryHepMC.h
+++ b/include/eicsmear/erhic/EventFactoryHepMC.h
@@ -2,19 +2,12 @@
 #define INCLUDE_EICSMEAR_ERHIC_EVENTFACTORYHEPMC_H_
 
 #include "eicsmear/erhic/EventFactory.h"
-#include "eicsmear/smear/EventSmear.h"
 
-#include <HepMC3/ReaderAsciiHepMC2.h>
 #include <HepMC3/GenEvent.h>
 #include <HepMC3/GenVertex.h>
 #include <HepMC3/GenParticle.h>
 
 #include<map>
-
-namespace HepMC3
-{
-  class ReaderAsciiHepMC2;
-}
 
 namespace erhic {
 

--- a/src/erhic/File.cxx
+++ b/src/erhic/File.cxx
@@ -538,9 +538,14 @@ const FileType* FileFactory::GetFile(const std::string& name) const {
 
 const FileType* FileFactory::GetFile(std::istream& is) const {
   std::string line;
+// the first non empty line in a hepmc file gives the version so
+// we save the initial istream position so we can reset it to
+// this position if we find it is a hepmc file
+  std::streampos oldpos = is.tellg();
   std::getline(is, line);
   if (line.empty())
   {
+    oldpos = is.tellg();
     std::getline(is, line);
   }
   // Use TString::ToLower() to convert the input name to all
@@ -570,6 +575,9 @@ const FileType* FileFactory::GetFile(std::istream& is) const {
     file = GetFile("sartre");
   } else if (str.Contains("hepmc")) {
     file = GetFile("hepmc");
+// put stream position back to first line so we can extract
+// the version from it
+    is.seekg (oldpos);
   }  // if
   return file;
 }


### PR DESCRIPTION
This PR adds the capability to read also HepMC3 formatted files. The change was straightforward where the reading was concerned, extracting the version and propagating this information to the reading was a bit more tricky. I hijacked the FindFirstEvent() method for this which is called before the processing. It reads now the first line, extracts the version and sets a flag which is later used to instantiate the specific reader.