### PR TITLE
Removed faulty genre check to support smearing muons. 

### DIFF
--- a/src/smear/Acceptance.cxx
+++ b/src/smear/Acceptance.cxx
@@ -45,9 +45,13 @@ void Acceptance::AddParticle(int n) {
 
 bool Acceptance::Is(const erhic::VirtualParticle& prt) const {
   // Check for genre first (em, hadronic, any)
-  if (PGenre(prt) == 0 || (mGenre != 0 && PGenre(prt) != mGenre)) {
+  // if (PGenre(prt) == 0 || (mGenre != 0 && PGenre(prt) != mGenre)) {
+  //   return false;
+  // }  // if
+  if ( mGenre != 0 && PGenre(prt) != mGenre ) {
     return false;
   }  // if
+
   // Check if the particle charge matches the required value.
   if (mCharge != kAllCharges) { // Don't need to check if accepting all
     // Try to find the particle's charge via its TParticlePDG object.

--- a/src/smear/Detector.cxx
+++ b/src/smear/Detector.cxx
@@ -181,8 +181,17 @@ ParticleMCS* Detector::Smear(const erhic::VirtualParticle& prt) const {
 	}
       } else if ( MomComponentsChanged + AngComponentsChanged != 3){
 	// - Momentum is exactly defined by three independent quantities, including theta and phi
-	cerr << "Expected 0 (excluding phi, theta) or exactly 3 ((excluding phi, theta) smeared momentum quantities." << endl;
+	cerr << "Expected 0 (excluding phi, theta) or exactly 3 (excluding phi, theta) smeared momentum quantities." << endl;
 	cerr << "For legacy smear scripts, use det.SetLegacyMode ( true );" << endl;
+	cerr << "MomComponentsChanged = " << MomComponentsChanged << endl;
+	cerr << prt.GetEta() << endl;
+	cerr << prtOut->IsPSmeared() << endl;
+	cerr << prtOut->IsPtSmeared() << endl;
+	cerr << prtOut->IsPxSmeared() << endl;
+	cerr << prtOut->IsPySmeared() << endl;
+	cerr << prtOut->IsPzSmeared() << endl;	
+	cerr << "AngComponentsChanged = " << AngComponentsChanged << endl;	
+	cerr << " pid : " << prt.Id() << endl;
 	throw std::runtime_error ("Failed consistency check in Detector::Smear()");
       } else {
 	// We now have exactly three out of P, px, py, pz, pt, phi, theta. Compute the rest.


### PR DESCRIPTION
Note that now muons may need to be caught explicitly in some smearing scripts.

This addresses 
https://github.com/eic/eic-smear/issues/7

Makes it necessary to update  eicsmeardetectors as well, see connected PR https://github.com/eic/eicsmeardetectors/pull/10
