### PR TITLE
Beagle conversion to HepMC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -118,6 +118,7 @@ if(HepMC3_FOUND)
     PRIVATE
     src/erhic/EventFactoryHepMC.cxx
     src/erhic/TreeToHepMC.cxx
+    src/erhic/FilterTreeToHepMC.cxx
     )
   target_include_directories(eicsmear
     PRIVATE

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,7 @@
 # from the cmake build directory.
 
 cmake_minimum_required(VERSION 3.10)
-project(eicsmear VERSION 1.1.7 LANGUAGES CXX )
+project(eicsmear VERSION 1.1.8 LANGUAGES CXX )
 
 # cmake needs a bit of help to find modules
 set(

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,4 +1,11 @@
 Author: Kolja Kauder <kkauder@gmail.com>
+Date:   Fri Sep 24 11:45:06 2021 -0400
+	HepMC3 conversion works for BeAGLE
+	HepMC2 is also an option
+	Initialize orig1 in ctor
+	declared version 1.1.8
+
+Author: Kolja Kauder <kkauder@gmail.com>
 Date:   Tue Aug 17 14:02:57 2021 -0400
 	Added a ROOT tree to HepMC3 converter.
 	Declared version 1.1.7

--- a/Doxyfile
+++ b/Doxyfile
@@ -38,7 +38,7 @@ PROJECT_NAME           = eic-smear
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = 1.1.7
+PROJECT_NUMBER         = 1.1.8
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ A wrapper allows to start ROOT with libraries loaded and displays
 version information as well as the library locations.
 ```
 $ eic-smear
-Using eic-smear version: 1.1.1
+Using eic-smear version: 1.1.8
 Using these eic-smear libraries :
 /Users/kkauder/software/lib/libeicsmear.dylib
 /Users/kkauder/software/lib/libeicsmeardetectors.dylib
@@ -139,7 +139,7 @@ eic-smear's ROOT trees can be converted to HepMC3 output using the `TreeToHepMC`
 macro, e.g.:
 ```
 $ eic-smear
-Using eic-smear version: 1.1.7
+Using eic-smear version: 1.1.8
 Using these eic-smear libraries :
 /Users/kkauder/software/lib/libeicsmear.dylib
 /Users/kkauder/software/lib/libeicsmeardetectors.dylib
@@ -151,9 +151,11 @@ or
 $ echo 'BuildTree("pythia6.txt"); TreeToHepMC("pythia6.root")' | eic-smear
 
 ```
-In its current form, BeAGLE input is not yet supported for the converter due to
-BeAGLE's support for multiple parent particles.
-It has been tested to work with HepMC tools and rivet for pythia6 and sartre.
+BeAGLE's structure is flattened. All intermediate particles are there,
+but their parental struture may not be preserved.
+For all generators, including BeAGLE, hadronic and leptonic decays
+should be correct. 
+It has been tested to work with HepMC tools and rivet as well as eAST.
 Any feedback for these or other generators is very welcome!
 
 Note: The necessity to first generate ROOT trees as an intermediate step is

--- a/cint/LinkDef.h
+++ b/cint/LinkDef.h
@@ -21,6 +21,7 @@
 
 #pragma link C++ function BuildTree;
 #pragma link C++ function TreeToHepMC;
+#pragma link C++ function FilterTreeToHepMC;
 
 // Particle classes
 

--- a/include/eicsmear/erhic/ParticleMC.h
+++ b/include/eicsmear/erhic/ParticleMC.h
@@ -304,7 +304,7 @@ class ParticleMCbase : public VirtualParticle {
 
   /** Sets the index of this particle's other parent if it has one.
    By default this is zero, indicating no parent. */
-  virtual void SetParent1Index(int i) { orig1 = i; }
+  virtual void SetParentIndex1(int i) { orig1 = i; }
 
   /** Sets the index of this particle's first child. By default this
    is zero, indicating no children. */

--- a/include/eicsmear/functions.h
+++ b/include/eicsmear/functions.h
@@ -72,6 +72,15 @@ Long64_t TreeToHepMC(const std::string& inputFileName,
 		     Long64_t maxEvent = 0);
 
 /**
+ \fn
+ Identical to TreeToHepMC with an added tweak to filter on certain events.
+ Currently, only accept events with a charmed final state
+ */
+Long64_t FilterTreeToHepMC(const std::string& inputFileName,
+			   const std::string& outputDirName = ".",
+			   Long64_t maxEvent = 0);
+
+/**
  Produces a DOT file describing the particle content of the event.
  */
 class EventToDot {

--- a/include/eicsmear/functions.h
+++ b/include/eicsmear/functions.h
@@ -69,7 +69,8 @@ Long64_t BuildTree(const std::string& inputFileName,
  */
 Long64_t TreeToHepMC(const std::string& inputFileName,
 		     const std::string& outputDirName = ".",
-		     Long64_t maxEvent = 0);
+		     Long64_t maxEvent = 0,
+		     const bool createHepMC2=false);
 
 /**
  \fn

--- a/include/eicsmear/functions.h
+++ b/include/eicsmear/functions.h
@@ -26,7 +26,7 @@ namespace erhic {
   /** 
       Simple namespace-wide constant to determine the version
   */
-  const std::string EicSmearVersionString = "1.1.7";
+  const std::string EicSmearVersionString = "1.1.8";
 
 }
 

--- a/src/erhic/EventFactoryHepMC.cxx
+++ b/src/erhic/EventFactoryHepMC.cxx
@@ -256,7 +256,7 @@ namespace erhic {
 	    if ( allparents.size() >= 2){
 	      // smallest and highest are stored
 	      track->SetParentIndex( *min_element(allparents.begin(), allparents.end() ) );
-	      track->SetParent1Index( *max_element(allparents.begin(), allparents.end() ) );
+	      track->SetParentIndex1( *max_element(allparents.begin(), allparents.end() ) );
 	    }
 
 	    // same for children

--- a/src/erhic/ParticleMC.cxx
+++ b/src/erhic/ParticleMC.cxx
@@ -57,6 +57,7 @@ namespace erhic {
 , KS(0)
 , id(0)
 , orig(0)
+, orig1(0)
 , daughter(0)
 , ldaughter(0)
 , px(0.)
@@ -97,7 +98,6 @@ namespace erhic {
 
       ss >>
 	//changed by liang to add particle mother1
-	//    I >> KS >> id >> orig >> daughter >> ldaughter >>
 	I >> KS >> id >> orig1 >> orig >> daughter >> ldaughter >>
 	px >> py >> pz >> E >> m >> xv >> yv >> zv
 	//added by liang to include add particle data structure
@@ -334,61 +334,4 @@ void ParticleMCbase::SetVertex(const TVector3& v) {
   yv = v.Y();
   zv = v.Z();
 }
-
-#if _OLD_
-ParticleMCeA::ParticleMCeA(const std::string& line)
-: /*I(-1)
-, KS(-1)
-, id(std::numeric_limits<Int_t>::min())
-, orig(-1)
-, daughter(-1)
-, ldaughter(-1)
-, px(0.)
-, py(0.)
-, pz(0.)
-, E(0.)
-, m(0.)
-, pt(0.)
-, xv(0.)
-, yv(0.)
-, zv(0.)
-, parentId(std::numeric_limits<Int_t>::min())
-, p(0.)
-, theta(0.)
-, phi(0.)
-, rapidity(0.)
-, eta(0.)
-, z(0.)
-, xFeynman(0.)
-, thetaGamma(0.)
-, ptVsGamma(0.)
-, phiPrf(0.) 
-//added by liang to include add particle data structure
-,*/ orig1(-1)
-, charge(-999)
-, massNum(-999) 
-, NoBam(-999) {
-  // Initialise to nonsense values to make input errors easy to spot
-  if (!line.empty()) {
-    static std::stringstream ss;
-    ss.str("");
-    ss.clear();
-    ss << line;
-    ss >>
-	//changed by liang to add particle mother1
-//    I >> KS >> id >> orig >> daughter >> ldaughter >>
-    I >> KS >> id >> orig1 >> orig >> daughter >> ldaughter >>
-    px >> py >> pz >> E >> m >> xv >> yv >> zv
-	//added by liang to include add particle data structure
-	>> massNum >> charge >> NoBam;
-    // We should have no stream errors and should have exhausted
-    // the whole of the stream filling the particle.
-    if (ss.fail() || !ss.eof()) {
-      throw std::runtime_error("Bad particle input: " + line);
-    }  // if
-    ComputeDerivedQuantities();
-  }  // if
-}
-#endif
-
 }  // namespace erhic

--- a/src/erhic/TreeToHepMC.cxx
+++ b/src/erhic/TreeToHepMC.cxx
@@ -554,7 +554,6 @@ Long64_t TreeToHepMC(const std::string& inputFileName,
     hep_hadron->set_status(4);
     GenVertexPtr v_hadron = std::make_shared<GenVertex>();
 
-    hep_lepton->set_status(4);
     v_hadron->add_particle_in (hep_hadron);
     hepmc3evt.add_vertex(v_hadron);
 

--- a/src/erhic/TreeToHepMC.cxx
+++ b/src/erhic/TreeToHepMC.cxx
@@ -275,6 +275,11 @@ Long64_t TreeToHepMC(const std::string& inputFileName,
 		      && !TString(pdg->ParticleClass()).Contains("Meson")
 		      ){
 	    inParticle->SetStatus(12);
+	    inParticle->SetParentIndex( bosonindex );
+	    inParticle->SetParentIndex1( 0 );
+	    
+	    inParticle->SetChild1Index( beagle_final_index ); // not needed but logically true
+	    inParticle->SetChildNIndex( 0 );   
 	  } else{
 	    // properly labeled as 2. We better have children
 	    if ( inParticle->GetChild1Index() == 0 ){
@@ -290,7 +295,8 @@ Long64_t TreeToHepMC(const std::string& inputFileName,
 	      std::cout << "Processing track " << t << " with index " << inParticle->GetIndex() << std::endl;
 	      std::cout << "Warning: I am a hadron or lepton with status 2, but I have too many parents. "  << std::endl;
 	      std::cout << "Discarding the older one"  << std::endl;
-	      inParticle->SetParentIndex( inParticle->GetParentIndex1() );
+	      // std::cout << inParticle->GetParentIndex() << "  " << inParticle->GetParentIndex1() << endl;
+	      inParticle->SetParentIndex( std::max ( inParticle->GetParentIndex(), inParticle->GetParentIndex1() ) );
 	      inParticle->SetParentIndex1( 0 );
 	    }
 	    auto mom = inParticle->GetParent();
@@ -596,25 +602,19 @@ Long64_t TreeToHepMC(const std::string& inputFileName,
       auto hep_mom = hep_boson;
       int momindex = inParticle->GetParentIndex();
       auto statusHepMC = inParticle->GetStatus();
-      
-    //   if ( beaglemode ){
-    // 	if ( momindex == beagle_final_index ){
-    // 	  v_beagle_final->add_particle_out(hep_in);
-    // 	  continue;
-    // 	}
-	
-    // 	if ( momindex == beagle_final_index ){
-    // 	  v_beagle_final->add_particle_out(hep_in);
-    // 	  continue;
-    // 	}
-	
-    //   } else {
-    // 	v_hadron->add_particle_out(hep_in);
-    // 	v_beagle_final->add_particle_in(hep_in);
-    //   }
-    //   continue;
-    // }
 
+      // // DEBUG!
+      // // suppress all the intermediate nucleons
+      // // this may be worth doing anyway  just to reduce filesize
+      // if ( beaglemode && statusHepMC==3 ) continue;
+      // if ( beaglemode && statusHepMC==14 ) continue;
+      // if ( beaglemode && statusHepMC==18 ) continue;
+      // if ( beaglemode && statusHepMC==12 ) continue;
+      // // This is purely for legibility, these particles should stay!
+      // // note: 80000 are lighter ions, without specification
+      // // if ( beaglemode && statusHepMC==1 && momindex == beagle_final_index
+      // // 	   && ( hep_in->pid() == 2112 || hep_in->pid() == 2212 || hep_in->pid() == 80000 ) ) continue;
+      
       // beagle finals 
       if ( momindex == beagle_final_index ){
 	v_beagle_final->add_particle_out(hep_in);

--- a/src/erhic/TreeToHepMC.cxx
+++ b/src/erhic/TreeToHepMC.cxx
@@ -93,10 +93,10 @@ Long64_t TreeToHepMC(const std::string& inputFileName,
     return -1;
   }  // if
 
-  if (branchClass->InheritsFrom("erhic::EventBeagle")) {
-    cout << "BeAGLE input is currently not supported (can't fix mother-daughter structure yet)" << endl;
-    return -1;    
-  }
+  // if (branchClass->InheritsFrom("erhic::EventBeagle")) {
+  //   cout << "BeAGLE input is currently not supported (can't fix mother-daughter structure yet)" << endl;
+  //   return -1;    
+  // }
 
   // Run info
   std::shared_ptr<GenRunInfo> run = std::make_shared<GenRunInfo>();
@@ -256,13 +256,29 @@ Long64_t TreeToHepMC(const std::string& inputFileName,
 	      // return -1;
 	    }
 	  } else { // We have more than one parent, are they correct?
-	    if ( myindex < p1 || myindex > pN ){
-	      std::cout << "Processing event " << i << std::endl;
-	      std::cout << "Processing track " << t << " with index " << myindex << std::endl;
-	      std::cout << "     Processing child with index " << child->GetIndex() << std::endl;
-	      cerr << "My child thinks its mothers range between " << p1 << " and " << pN
-		   << ", but I am " << myindex << endl;
-	      return -1;
+	    // This would be the logic if p1 and pN _span_
+	    // if ( myindex < p1 || myindex > pN ){
+	    //   std::cout << "Processing event " << i << std::endl;
+	    //   std::cout << "Processing track " << t << " with index " << myindex << std::endl;
+	    //   std::cout << "     Processing child with index " << child->GetIndex() << std::endl;
+	    //   cerr << "My child thinks its mothers range between " << p1 << " and " << pN
+	    // 	   << ", but I am " << myindex << endl;
+	    //   // return -1;
+	    // }
+	    // Instead, it seems that BeAGLE (mostly?) assumes this to mean
+	    // exactly two parents, usually far apart in index
+	    if ( myindex != p1 && myindex != pN ){
+	      // Problematic situation in BeAGLE:
+	      //  I       S        PID       P1       P2       D1       D2
+	      // ==========================================================
+	      //  17     18       2112        0        0      260      261
+	      // ...
+	      // 254     19        111       41      244      260      261
+	      // 255      2       2212       41      244      260      261
+	      // ...
+	      // 260     16       2112       17      254        0        0
+	      // 261     16       2212       17      254        0        0
+
 	    }
 	  }
 	}

--- a/src/erhic/TreeToHepMC.cxx
+++ b/src/erhic/TreeToHepMC.cxx
@@ -454,6 +454,7 @@ Long64_t TreeToHepMC(const std::string& inputFileName,
     int index_hadron = hadron->GetIndex();
     if ( index_hadron !=2 ) std::cout << "Warning: Found BeamHadron at " << index_hadron << endl;
     auto hep_hadron = hepevt_particles.at( index_hadron-1);
+    hep_hadron->set_status(4);
     GenVertexPtr v_hadron = std::make_shared<GenVertex>();
 
     hep_lepton->set_status(4);

--- a/src/erhic/TreeToHepMC.cxx
+++ b/src/erhic/TreeToHepMC.cxx
@@ -24,6 +24,7 @@
 #include "HepMC3/GenParticle.h"
 #include "HepMC3/GenCrossSection.h"
 #include "HepMC3/WriterAscii.h"
+#include "HepMC3/WriterAsciiHepMC2.h"
 #include "HepMC3/Attribute.h"
 
 using std::cout;
@@ -48,7 +49,8 @@ using HepMC3::GenCrossSectionPtr;
  */
 Long64_t TreeToHepMC(const std::string& inputFileName,
 		     const std::string& outputDirName,
-		     Long64_t maxEvent) {
+		     Long64_t maxEvent,
+		     const bool createHepMC2) {
 
   // Get the input file name, stripping any leading directory path via
   // use of the BaseName() method from TSystem.
@@ -150,7 +152,12 @@ Long64_t TreeToHepMC(const std::string& inputFileName,
   }
 
   // Open the output file.
-  HepMC3::WriterAscii file(outName.Data(),run);
+  std::shared_ptr<HepMC3::Writer> file;
+  if ( createHepMC2 ){
+    file = std::make_shared<HepMC3::WriterAsciiHepMC2>(outName.Data(),run);
+  } else {
+    file = std::make_shared<HepMC3::WriterAscii>(outName.Data(),run);
+  }
 
   // Event Loop
   if (mcTree->GetEntries() < maxEvent || maxEvent < 1) {
@@ -651,7 +658,7 @@ Long64_t TreeToHepMC(const std::string& inputFileName,
 
     }
     // Done! Write the event.
-    file.write_event(hepmc3evt);
+    file->write_event(hepmc3evt);
 
     // There's a bunch of cleanup one should do now, with all the dynamical
     // vertices and particles. BUT shared_ptr should take care of that. Revisit if there are memory leaks.


### PR DESCRIPTION
Beagle is now supported. 
Hepmc2 output is optional.
Also fixes a missing initialization of orig1 in ParticleMC