### PR TITLE
Instantiate needed erhic::File<> variants in the File.cxx's translation unit

### DIFF
--- a/src/erhic/File.cxx
+++ b/src/erhic/File.cxx
@@ -499,6 +499,19 @@ File<T>::~File() {
   }  // if
 }
 
+template class File<EventDjangoh>;
+template class File<EventDpmjet>;
+template class File<EventMilou>;
+template class File<EventPepsi>;
+template class File<EventPythia>;
+template class File<EventBeagle>;
+template class File<EventRapgap>;
+template class File<EventGmcTrans>;
+template class File<EventSimple>;
+template class File<EventDEMP>;
+template class File<EventSartre>;
+// File<EventHepMC> is specialized in the File.h
+
 std::string FileType::GetGeneratorName() const {
     return generatorname;
 }


### PR DESCRIPTION
Templated classes have to be instantiated explicitly. gcc can be forgiving about this, but other compilers are not always like that.

Fixes: #10