### PR TITLE
Hepmc djangoh

### DIFF
--- a/src/erhic/TreeToHepMC.cxx
+++ b/src/erhic/TreeToHepMC.cxx
@@ -723,17 +723,15 @@ Long64_t TreeToHepMC(const std::string& inputFileName,
       int momindex = inParticle->GetParentIndex();
       auto statusHepMC = inParticle->GetStatus();
 
-      //if( (statusHepMC==1) && (abs(inParticle->Id())==1 || abs(inParticle->Id())==2 || abs(inParticle->Id())==3) ){
-	//cout << "Event is " << i << endl;
-	//cout<<"Found a final-state quark!!"<<endl; 
-      //}
-      
-      if( statusHepMC==1 && 
+      //For Djangoh events which fail to hadronize, shift the parent of the
+      //final-state parton from the incoming electron beam to th hadron beam     
+      if (branchClass->InheritsFrom("erhic::EventDjangoh")){
+      	if( statusHepMC==1 && momindex==1 &&
 	  (abs(inParticle->Id())==1 || abs(inParticle->Id())==2 || abs(inParticle->Id())==3 || 
-	   abs(inParticle->Id())==90 || inParticle->Id()==91 || inParticle->Id()==92)
-	){
-		if(momindex==1) momindex+=1;	
+	   abs(inParticle->Id())==90 || inParticle->Id()==91 || inParticle->Id()==92) ){ 
+		momindex+=1;
 	}
+      }
       
       // suppress all the intermediate nucleons
       // this may be worth doing anyway  just to reduce filesize

--- a/src/erhic/TreeToHepMC.cxx
+++ b/src/erhic/TreeToHepMC.cxx
@@ -465,13 +465,18 @@ Long64_t TreeToHepMC(const std::string& inputFileName,
 	if ( cN==0 ) cN =c1;
 	if ( c1>cN ) std::swap(c1,cN);
 	if ( c1>0 ) {
-	  bool evtokay=true;
+	  
+	  //In a small number of Djangoh events, the particle list will be incomplete.
+	  //A particle will have a child which is not included in the particle list.
+	  bool djangohproblem = false;
+
 	  for ( UShort_t c = c1; c<=cN; ++c ){ // sigh. index starts at 1, tracks at 0;
 	    Particle* child = inEvent->GetTrack(c-1);
 	    if ( !child ) {
 	      cerr << "Trying to access a non-existant child" << endl;
 	      cerr << "Event is " << i << "  Problem index is " << c << endl;
-	      evtokay=false;
+	      cerr << "If this is not a djangoh file, please contact the eic-smear developers"<<endl;
+	      djangohproblem = true;
 	      break;
 	    }
  
@@ -523,7 +528,7 @@ Long64_t TreeToHepMC(const std::string& inputFileName,
 	      // }
 	    }
 	  }
-	  if(!evtokay) continue;
+	  if(djangohproblem) continue;
 	}
 	// Do my parents acknowledge me?
 	auto p1 = inParticle->GetParentIndex();

--- a/src/erhic/TreeToHepMC.cxx
+++ b/src/erhic/TreeToHepMC.cxx
@@ -622,6 +622,12 @@ Long64_t TreeToHepMC(const std::string& inputFileName,
 	while ( statusHepMC >200 ) statusHepMC-=10;
       }
 
+      //In the Pythia 6 convention, status=4 indicates a particle which could
+      //have decayed but did not within the allowed volume around the vertex.
+      //We adjust these particles to have status=1 in the HepMC file to avoid
+      //confusion with the beam particles.
+      if( statusHepMC == 4) statusHepMC = 1;
+
       // Create GenParticle
       hepevt_particles.push_back( std::make_shared<GenParticle>( pv, inParticle->Id(), statusHepMC ));
       hepevt_particles.back()->set_generated_mass( inParticle->GetM() );

--- a/src/erhic/TreeToHepMC.cxx
+++ b/src/erhic/TreeToHepMC.cxx
@@ -722,6 +722,18 @@ Long64_t TreeToHepMC(const std::string& inputFileName,
       auto hep_mom = hep_hadron;
       int momindex = inParticle->GetParentIndex();
       auto statusHepMC = inParticle->GetStatus();
+
+      //if( (statusHepMC==1) && (abs(inParticle->Id())==1 || abs(inParticle->Id())==2 || abs(inParticle->Id())==3) ){
+	//cout << "Event is " << i << endl;
+	//cout<<"Found a final-state quark!!"<<endl; 
+      //}
+      
+      if( statusHepMC==1 && 
+	  (abs(inParticle->Id())==1 || abs(inParticle->Id())==2 || abs(inParticle->Id())==3 || 
+	   abs(inParticle->Id())==90 || inParticle->Id()==91 || inParticle->Id()==92)
+	){
+		if(momindex==1) momindex+=1;	
+	}
       
       // suppress all the intermediate nucleons
       // this may be worth doing anyway  just to reduce filesize

--- a/src/erhic/TreeToHepMC.cxx
+++ b/src/erhic/TreeToHepMC.cxx
@@ -718,7 +718,8 @@ Long64_t TreeToHepMC(const std::string& inputFileName,
       int index = inParticle->GetIndex();
       if ( index==index_lepton || index==index_boson || index==index_hadron) continue;
       auto hep_in = hepevt_particles.at( index-1);
-      auto hep_mom = hep_boson;
+      // auto hep_mom = hep_boson;
+      auto hep_mom = hep_hadron;
       int momindex = inParticle->GetParentIndex();
       auto statusHepMC = inParticle->GetStatus();
       

--- a/src/erhic/TreeToHepMC.cxx
+++ b/src/erhic/TreeToHepMC.cxx
@@ -465,12 +465,14 @@ Long64_t TreeToHepMC(const std::string& inputFileName,
 	if ( cN==0 ) cN =c1;
 	if ( c1>cN ) std::swap(c1,cN);
 	if ( c1>0 ) {
+	  bool evtokay=true;
 	  for ( UShort_t c = c1; c<=cN; ++c ){ // sigh. index starts at 1, tracks at 0;
 	    Particle* child = inEvent->GetTrack(c-1);
 	    if ( !child ) {
 	      cerr << "Trying to access a non-existant child" << endl;
 	      cerr << "Event is " << i << "  Problem index is " << c << endl;
-	      throw;
+	      evtokay=false;
+	      break;
 	    }
  
 	    // std::cout << "     Processing child with index " << child->GetIndex() << std::endl;
@@ -521,6 +523,7 @@ Long64_t TreeToHepMC(const std::string& inputFileName,
 	      // }
 	    }
 	  }
+	  if(!evtokay) continue;
 	}
 	// Do my parents acknowledge me?
 	auto p1 = inParticle->GetParentIndex();


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR contains several changes to the TreeToHepMC, mostly for Djangoh events. The following types of events are now handled: events where a particle has a child which is not included in the particle list are now converted to HepMC; events with hanging vertices are now associated with the hadron beam; events with non-hadronizing partons have those partons associated with the hadron beam vertex; and long-lived hadrons have the correct HepMC3 status number.

After these changes, the created HepMC file can successfully be processed by the beam effects afterburner.

### What kind of change does this PR introduce?
- [ x] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ x] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?

### Does this PR change default behavior?
