### PR TITLE
Fixed cross-section unit bug in HepMC conversion

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,7 @@
 # from the cmake build directory.
 
 cmake_minimum_required(VERSION 3.10)
-project(eicsmear VERSION 1.1.11 LANGUAGES CXX )
+project(eicsmear VERSION 1.1.12 LANGUAGES CXX )
 
 # cmake needs a bit of help to find modules
 set(

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,4 +1,9 @@
 Author: Kolja Kauder <kkauder@gmail.com>
+Date:   Thu Sep 14 10:56:54 2023 -0400
+	Fixed cross-section unit bug in HepMC conversion
+	Declared version 1.1.12
+
+Author: Kolja Kauder <kkauder@gmail.com>
 Date:   Fri Aug 18 2:30:00 2023 -0400
 	Declared version 1.1.11
 

--- a/Doxyfile
+++ b/Doxyfile
@@ -38,7 +38,7 @@ PROJECT_NAME           = eic-smear
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = 1.1.11
+PROJECT_NUMBER         = 1.1.12
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ A wrapper allows to start ROOT with libraries loaded and displays
 version information as well as the library locations.
 ```
 $ eic-smear
-Using eic-smear version: 1.1.11
+Using eic-smear version: 1.1.12
 Using these eic-smear libraries :
 /Users/kkauder/software/lib/libeicsmear.dylib
 /Users/kkauder/software/lib/libeicsmeardetectors.dylib
@@ -139,7 +139,7 @@ eic-smear's ROOT trees can be converted to HepMC output using the `TreeToHepMC`
 macro, e.g.:
 ```
 $ eic-smear
-Using eic-smear version: 1.1.11
+Using eic-smear version: 1.1.12
 Using these eic-smear libraries :
 /Users/kkauder/software/lib/libeicsmear.dylib
 /Users/kkauder/software/lib/libeicsmeardetectors.dylib

--- a/include/eicsmear/functions.h
+++ b/include/eicsmear/functions.h
@@ -26,7 +26,7 @@ namespace erhic {
   /** 
       Simple namespace-wide constant to determine the version
   */
-  const std::string EicSmearVersionString = "1.1.11";
+  const std::string EicSmearVersionString = "1.1.12";
 
 }
 

--- a/src/erhic/TreeToHepMC.cxx
+++ b/src/erhic/TreeToHepMC.cxx
@@ -127,12 +127,11 @@ Long64_t TreeToHepMC(const std::string& inputFileName,
   // Need to also use HepMC3::GenCrossSection for rivet
   // Christian Bierlich recommends just using the same for each event
 
-  // crossSection is in mbarn! Converting to HepMC's pb standard
-  // The super set, not all generators supply all of these
   double crossSection = 1.0;
   double crossSectionError = 0.0;
-  // could also record  accepted_events and attempted_events
   
+  // The super set, not all generators supply all of these
+  // could also record  accepted_events and attempted_events
   std::vector <string> RunAttributes = {"crossSection", "crossSectionError", "nEvents", "nTrials" };
   for ( auto att : RunAttributes ){
     TObjString* ObjString(nullptr);
@@ -140,11 +139,13 @@ Long64_t TreeToHepMC(const std::string& inputFileName,
     if (ObjString) {
       double value = std::atof(ObjString->String());
       if ( att == "crossSection" ) {
-	value *=1e9;
+	// crossSection is in microbarn! Converting to HepMC's pb standard
+	value *=1e6;
 	crossSection = value;
       }
       if ( att == "crossSectionError" ){
-	value *=1e9;
+	// crossSection is in microbarn! Converting to HepMC's pb standard
+	value *=1e6;
 	crossSectionError = value;
       }
       cout << " Adding to the header: " << att << "  " << value << endl;


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Fixed cross-section unit bug in HepMC conversion from assuming millibarn input to the correct microbarn.
https://github.com/eic/eic-smear/issues/26

### What kind of change does this PR introduce?
- [x] Bug fix (issue #26)

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [x] Changes have been communicated to collaborators
Working with prod group on how to best disseminate this change and what files to reproduce.

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.

