### PR TITLE
Optimization kills templated method.

### DIFF
--- a/src/erhic/EventFactory.cxx
+++ b/src/erhic/EventFactory.cxx
@@ -202,6 +202,8 @@ namespace erhic {
       }
   }
 
+  // Explicitly needed by gcc to not optimize it away and bug out
+  template Int_t EventFromAsciiFactory<erhic::EventHepMC>::FinishEvent();
     
 }  // namespace erhic
 


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Added an explicit template instantiation that otherwise can get optimized away and lead to a linker error in gcc.

Turning on `-O2` (e.g. implicitly with `-DCMAKE_BUILD_TYPE=RelWithDebInfo`) on gcc14 leads to 
```
bin/ld: libeicsmear.so: undefined reference to `erhic::EventFromAsciiFactory<erhic::EventHepMC>::FinishEvent()'
```
A similar bug was caught by Chris P. in https://github.com/BNLNPPS/nopayloadclient/pull/12, and I extrapolated a fix for this issue.

### What kind of change does this PR introduce?
- [x] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No

### Does this PR change default behavior?
No
