### PR TITLE
Photon eta fix

### DIFF
--- a/src/erhic/ParticleMC.cxx
+++ b/src/erhic/ParticleMC.cxx
@@ -132,6 +132,7 @@ void ParticleMCbase::Print(Option_t* /* option */) const {
   std::endl;
 }
 
+//Need to add photon eta fix here
 void ParticleMCbase::ComputeDerivedQuantities() {
   // Calculate quantities that depend only on the properties already read.
   pt = sqrt(pow(px, 2.) + pow(py, 2.));

--- a/src/erhic/ParticleMC.cxx
+++ b/src/erhic/ParticleMC.cxx
@@ -144,14 +144,18 @@ void ParticleMCbase::ComputeDerivedQuantities() {
   Double_t Pminuspz = p - pz;
   if (Eminuspz <= 0.0 || Pminuspz == 0.0 ||
      Ppluspz == 0.0 || Epluspz <= 0.0) {
-    // Dummy values to avoid zero or infinite arguments in calculations
+    // (previous) Dummy values to avoid zero or infinite arguments in calculations
+    // calculating pseudorapidity (eta) with the polarangle
+    // leaving rapidity untouched for now
     rapidity = -19.;
-    eta = -19.;
+
   } else {
     rapidity = 0.5 * log(Epluspz / Eminuspz);
-    eta = 0.5 * log(Ppluspz / Pminuspz);
+    //eta = 0.5 * log(Ppluspz / Pminuspz);
+
   }  // if
   theta = atan2(pt, pz);
+  eta = (-1) * log(tan(theta/2));
   phi = TVector2::Phi_0_2pi(atan2(py, px));
 }
 

--- a/src/erhic/ParticleMC.cxx
+++ b/src/erhic/ParticleMC.cxx
@@ -132,7 +132,6 @@ void ParticleMCbase::Print(Option_t* /* option */) const {
   std::endl;
 }
 
-//Need to add photon eta fix here
 void ParticleMCbase::ComputeDerivedQuantities() {
   // Calculate quantities that depend only on the properties already read.
   pt = sqrt(pow(px, 2.) + pow(py, 2.));
@@ -142,20 +141,29 @@ void ParticleMCbase::ComputeDerivedQuantities() {
   Double_t Eminuspz = E - pz;
   Double_t Ppluspz = p + pz;
   Double_t Pminuspz = p - pz;
+
+  // rapidity
   if (Eminuspz <= 0.0 || Pminuspz == 0.0 ||
      Ppluspz == 0.0 || Epluspz <= 0.0) {
-    // (previous) Dummy values to avoid zero or infinite arguments in calculations
+    // Dummy values to avoid zero or infinite arguments in calculations
     // calculating pseudorapidity (eta) with the polarangle
     // leaving rapidity untouched for now
-    rapidity = -19.;
+    rapidity = -20.;
 
   } else {
     rapidity = 0.5 * log(Epluspz / Eminuspz);
-    //eta = 0.5 * log(Ppluspz / Pminuspz);
-
-  }  // if
+  }  // end if
+  // pseudorapidity 
   theta = atan2(pt, pz);
-  eta = (-1) * log(tan(theta/2));
+  if (theta < std::numeric_limits<float>::epsilon()){
+	  // dummy values to avoid infinity or zero in calculations 
+	  eta = 20.;
+  } else if ((M_PI - theta) < std::numeric_limits<float>::epsilon()){
+	  eta = -20.;
+  } else {
+	  eta = (-1) * log(tan(theta/2));
+  }
+
   phi = TVector2::Phi_0_2pi(atan2(py, px));
 }
 


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR introduces a recalculation of the pseudorapidity (eta) for all particles based on their polar angle (theta). The polar angle is compared against machine epsilon to prevent infinite arguments in calculation of the pseudorapidity. This recalculation allows for more appropriate eta distribution of especially the photons. 
[Photon-eta-fix_PullRequest.pdf](https://github.com/user-attachments/files/21186254/Photon-eta-fix_PullRequest.pdf)
Results in attached document are based on simulation of 1 million events.

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [x] Other: Updates formula for pseudorapidity calculation in Computation of Derived Quantities (ParticleMC.cxx)

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [x] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
I do not believe that this PR introduces any breaking changes from what I understand about breaking changes. Users will not need to make any changes to their code.
 
### Does this PR change default behavior?
This PR does not change default behavior.
