### PR TITLE
CMakeLists.txt: use keyword version of target_link_libraries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -314,14 +314,14 @@ endif(PYTHIA6_LIBDIR)
 ## Build the library
 ## this can be improved with newer root versions
 
-target_link_libraries(eicsmear ROOT::Core ROOT::RIO ROOT::Rint ROOT::Tree ROOT::EG ROOT::Physics -lz )
+target_link_libraries(eicsmear PUBLIC ROOT::Core ROOT::RIO ROOT::Rint ROOT::Tree ROOT::EG ROOT::Physics -lz )
 
 if(PYTHIA6_LIBDIR)
-  target_link_libraries(eicsmear ROOT::EGPythia6 ROOT::Eve )
+  target_link_libraries(eicsmear PUBLIC ROOT::EGPythia6 ROOT::Eve )
 endif(PYTHIA6_LIBDIR)
 
 if(HepMC3_FOUND)
-  target_link_libraries(eicsmear ${HEPMC3_LIBRARIES} )
+  target_link_libraries(eicsmear PUBLIC ${HEPMC3_LIBRARIES} )
 endif()
 
 ##############################################################################################################
@@ -332,7 +332,7 @@ endif()
 add_executable(eic-smear scripts/eic-smear.cxx)
 target_compile_features(eic-smear PUBLIC cxx_std_11)
 target_compile_options(eic-smear PRIVATE -Wall -Wextra -pedantic -g)
-target_link_libraries(eic-smear eicsmear )
+target_link_libraries(eic-smear PUBLIC eicsmear )
 target_include_directories(eic-smear
   PRIVATE
   ${ROOT_INCLUDE_DIRS}
@@ -358,7 +358,7 @@ if ( PYTHIA6_LIBDIR )
   target_compile_options(compiled_runpythia PRIVATE -Wall -Wextra -pedantic -g)
 
   
-target_link_libraries(compiled_runpythia
+target_link_libraries(compiled_runpythia PUBLIC
     eicsmear ROOT::Core ROOT::RIO ROOT::Rint ROOT::Tree ROOT::EG ROOT::EGPythia6 ROOT::Eve
     )
 endif(PYTHIA6_LIBDIR)


### PR DESCRIPTION
This fixes an issue with newer ROOT 6-38-00 (starting https://github.com/root-project/root/commit/fa2f683a878c0f85afe445d5d0301685faa71278):
```
CMake Error at CMakeLists.txt:317 (target_link_libraries):
  The keyword signature for target_link_libraries has already been used with
  the target "eicsmear".  All uses of target_link_libraries with a target
  must be either all-keyword or all-plain.

  The uses of the keyword signature are here:

   * /lib/cmake/RootMacros.cmake:716 (target_link_libraries)
```
This appears to still work with older ROOTs.