### PR TITLE
Suppress error message when not finding libsmeardetectors

### DIFF
--- a/scripts/eic-smear.cxx
+++ b/scripts/eic-smear.cxx
@@ -68,7 +68,7 @@ int main(int argc, char** argv)
   auto libeicsmearpath=gSystem->DynamicPathName("libeicsmear");
   // auto libdetectorpath="libeicsmeardetectors not found";
   auto libdetectorpath="";
-  if ( smeardets>0 ) {
+  if ( smeardets>=0 ) {
       libdetectorpath=gSystem->DynamicPathName("libeicsmeardetectors");
     }
   std::cout << "Using these eic-smear libraries : "<< std::endl

--- a/scripts/eic-smear.cxx
+++ b/scripts/eic-smear.cxx
@@ -60,9 +60,17 @@ int main(int argc, char** argv)
       return 0;
     }
   }    
-  gSystem->Load("libeicsmeardetectors");
+  auto ErrorIgnoreLevel=gErrorIgnoreLevel;
+  gErrorIgnoreLevel = kFatal; 
+  auto smeardets=gSystem->Load("libeicsmeardetectors");
+  gErrorIgnoreLevel = ErrorIgnoreLevel;
+  
   auto libeicsmearpath=gSystem->DynamicPathName("libeicsmear");
-  auto libdetectorpath=gSystem->DynamicPathName("libeicsmeardetectors");
+  // auto libdetectorpath="libeicsmeardetectors not found";
+  auto libdetectorpath="";
+  if ( smeardets>0 ) {
+      libdetectorpath=gSystem->DynamicPathName("libeicsmeardetectors");
+    }
   std::cout << "Using these eic-smear libraries : "<< std::endl
 	    << libeicsmearpath << std::endl
 	    << libdetectorpath << std::endl;

--- a/scripts/eic-smear.cxx
+++ b/scripts/eic-smear.cxx
@@ -66,7 +66,6 @@ int main(int argc, char** argv)
   gErrorIgnoreLevel = ErrorIgnoreLevel;
   
   auto libeicsmearpath=gSystem->DynamicPathName("libeicsmear");
-  // auto libdetectorpath="libeicsmeardetectors not found";
   auto libdetectorpath="";
   if ( smeardets>=0 ) {
       libdetectorpath=gSystem->DynamicPathName("libeicsmeardetectors");


### PR DESCRIPTION
### Briefly, what does this PR introduce?
See the issue. libeicsmeardetectors is no longer installed by default, so suppress the warning when we're not finding it.

### What kind of change does this PR introduce?
- [x] Bug fix (issue #35)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No
### Does this PR change default behavior?
No